### PR TITLE
fixes #70 : set position of minecart in sound instance when a player …

### DIFF
--- a/common/src/main/java/com/leobeliik/extremesoundmuffler/mixins/AbstractSoundInstanceMixin.java
+++ b/common/src/main/java/com/leobeliik/extremesoundmuffler/mixins/AbstractSoundInstanceMixin.java
@@ -1,0 +1,16 @@
+package com.leobeliik.extremesoundmuffler.mixins;
+
+import net.minecraft.client.resources.sounds.AbstractSoundInstance;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(AbstractSoundInstance.class)
+public interface AbstractSoundInstanceMixin {
+
+    @Accessor("x")
+    void setX(double x);
+    @Accessor("y")
+    void setY(double y);
+    @Accessor("z")
+    void setZ(double z);
+}

--- a/common/src/main/java/com/leobeliik/extremesoundmuffler/mixins/MinecartSoundMixin.java
+++ b/common/src/main/java/com/leobeliik/extremesoundmuffler/mixins/MinecartSoundMixin.java
@@ -1,0 +1,22 @@
+package com.leobeliik.extremesoundmuffler.mixins;
+
+import net.minecraft.client.resources.sounds.RidingMinecartSoundInstance;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.vehicle.AbstractMinecart;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RidingMinecartSoundInstance.class)
+public abstract class MinecartSoundMixin {
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void addPositionToInstance(Player player, AbstractMinecart minecart, boolean insideWater, CallbackInfo ci) {
+        BlockPos minecartPos = minecart.getOnPos();
+        ((AbstractSoundInstanceMixin)this).setX(minecartPos.getX());
+        ((AbstractSoundInstanceMixin)this).setY(minecartPos.getY());
+        ((AbstractSoundInstanceMixin)this).setZ(minecartPos.getZ());
+    }
+}

--- a/fabric/src/main/resources/extremesoundmuffler.mixins.json
+++ b/fabric/src/main/resources/extremesoundmuffler.mixins.json
@@ -6,7 +6,9 @@
   "client": [
     "InventoryScreenMixin",
     "CreativeInventoryScreenMixin",
-    "SoundMixin"
+    "SoundMixin",
+    "MinecartSoundMixin",
+    "AbstractSoundInstanceMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/forge/src/main/resources/extremesoundmuffler.mixins.json
+++ b/forge/src/main/resources/extremesoundmuffler.mixins.json
@@ -6,7 +6,9 @@
   "client": [
     "InventoryScreenMixin",
     "CreativeInventoryScreenMixin",
-    "SoundMixin"
+    "SoundMixin",
+    "MinecartSoundMixin",
+    "AbstractSoundInstanceMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/neoforge/src/main/resources/extremesoundmuffler.mixins.json
+++ b/neoforge/src/main/resources/extremesoundmuffler.mixins.json
@@ -6,7 +6,9 @@
   "client": [
     "InventoryScreenMixin",
     "CreativeInventoryScreenMixin",
-    "SoundMixin"
+    "SoundMixin",
+    "MinecartSoundMixin",
+    "AbstractSoundInstanceMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
…is riding inside. This allows anchors to check the range of the sound instance, and affect the volume accordingly

I have tested this within a small radius and when the minecart enters and exits the anchor, the sound is adjusted as expected. I think this is a quite clean way to handle it and has no effect on anything else that I can see.