### PR TITLE
Fix radius string

### DIFF
--- a/common/src/main/java/com/leobeliik/extremesoundmuffler/gui/MufflerScreen.java
+++ b/common/src/main/java/com/leobeliik/extremesoundmuffler/gui/MufflerScreen.java
@@ -489,7 +489,7 @@ public class MufflerScreen extends Screen implements ISoundLists, IColorsGui {
             stack.fill(x - 5, btnAccept.getY() + 23, editAnchorTitleBar.getX() + editAnchorTitleBar.getWidth() + 4, btnAccept.getY() + 24, whiteBG);//light bottom background border
             stack.fill(x - 6, y - 4, editAnchorTitleBar.getX() + editAnchorTitleBar.getWidth() + 3, btnAccept.getY() + 23, darkBG);//dark background
             stack.drawString(font, Component.translatable("main_screen.side_screen.title"), x - 2, y + 1, whiteText);
-            stack.drawString(font, Component.translatable("main_screen.side_screen.radius"), x - 2, editRadBar.getY() + 1, whiteText);
+            stack.drawString(font, Component.translatable("main_screen.side_screen.radius_edit"), x - 2, editRadBar.getY() + 1, whiteText);
         }
     }
 

--- a/common/src/main/resources/assets/extremesoundmuffler/lang/en_us.json
+++ b/common/src/main/resources/assets/extremesoundmuffler/lang/en_us.json
@@ -35,9 +35,10 @@
   "main_screen.side_screen.x": "X: %s",
   "main_screen.side_screen.y": "Y: %s",
   "main_screen.side_screen.z": "Z: %s",
-  "main_screen.side_screen.radius": "Radius:",
+  "main_screen.side_screen.radius": "Radius: %s",
   "main_screen.side_screen.dimension": "Dimension: %s",
   "main_screen.side_screen.title": "Title: ",
+  "main_screen.side_screen.radius_edit": "Radius: ",
 
   "tip.disable": "You can disable these tips in the config",
   "tip.change_volume": "You can change the volume of muffled sounds by dragging the slider",

--- a/common/src/main/resources/assets/extremesoundmuffler/lang/fr_fr.json
+++ b/common/src/main/resources/assets/extremesoundmuffler/lang/fr_fr.json
@@ -35,9 +35,10 @@
     "main_screen.side_screen.x": "X : %s",
     "main_screen.side_screen.y": "Y : %s",
     "main_screen.side_screen.z": "Z : %s",
-    "main_screen.side_screen.radius": "Rayon :",
+    "main_screen.side_screen.radius": "Rayon : %s",
     "main_screen.side_screen.dimension": "Dimension : %s",
     "main_screen.side_screen.title": "Titre : ",
+    "main_screen.side_screen.radius_edit": "Rayon : ",
 
     "tip.disable": "Vous pouvez désactiver ces astuces dans la configuration",
     "tip.change_volume": "Vous pouvez changer le volume des sons réduits en faisant glisser le curseur",

--- a/common/src/main/resources/assets/extremesoundmuffler/lang/pt_br.json
+++ b/common/src/main/resources/assets/extremesoundmuffler/lang/pt_br.json
@@ -35,9 +35,10 @@
     "main_screen.side_screen.x": "X: %s",
     "main_screen.side_screen.y": "Y: %s",
     "main_screen.side_screen.z": "Z: %s",
-    "main_screen.side_screen.radius": "Raio:",
+    "main_screen.side_screen.radius": "Raio: %s",
     "main_screen.side_screen.dimension": "Dimensão: %s",
     "main_screen.side_screen.title": "Título: ",
+    "main_screen.side_screen.radius_edit": "Raio: ",
   
     "tip.disable": "Você pode desativar essas dicas na configuração",
     "tip.change_volume": "Você pode alterar o volume de sons abafados arrastando o controle deslizante",


### PR DESCRIPTION
The same string was used to display the anchor radius and as the edit label, leading to the radius value not being displayed.

This PR adds a second string for the edit label and fixes the radius string to display the value.